### PR TITLE
Update plugin dependency

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -8,7 +8,7 @@ use NSRosenqvist\BaguetteGallery\Classes\Hooks;
 
 class Plugin extends \System\Classes\PluginBase
 {
-    public $require = ['Bedard.Resimg'];
+    public $require = ['OFFLINE.ResponsiveImages'];
 
     public function pluginDetails()
     {


### PR DESCRIPTION
Plugin `Bedard.Resimg` doesn't exist anymore, but `OFFLINE.ResponsiveImages` do the same job (add `srcset` attribute to images).

If you accept this change, please change it also at OctoberCMS marketplace.
